### PR TITLE
[prometheus-operator] Upgrade Chart to support prometheus-operator v0.59.1

### DIFF
--- a/charts/prometheus-operator/Chart.yaml
+++ b/charts/prometheus-operator/Chart.yaml
@@ -31,37 +31,133 @@ annotations:
       url: https://github.com/prometheus-operator/kube-prometheus
   artifacthub.io/crds: |
     - kind: AlertmanagerConfig
-      version: v1alpha1
+      version: monitoring.coreos.com/v1alpha1
       name: alertmanagerconfigs.monitoring.coreos.com
       description: AlertmanagerConfig defines a namespaced AlertmanagerConfig to be aggregated across multiple namespaces configuring one Alertmanager cluster.
     - kind: Alertmanager
-      version: v1
+      version: monitoring.coreos.com/v1
       name: alertmanagers.monitoring.coreos.com
       description: Alertmanager describes an Alertmanager cluster.
     - kind: PodMonitor
-      version: v1
+      version: monitoring.coreos.com/v1
       name: podmonitors.monitoring.coreos.com
       description: PodMonitor defines monitoring for a set of pods.
     - kind: Probe
-      version: v1
+      version: monitoring.coreos.com/v1
       name: probes.monitoring.coreos.com
       description: Probe defines monitoring for a set of static targets or ingresses.
     - kind: Prometheus
-      version: v1
+      version: monitoring.coreos.com/v1
       name: prometheuses.monitoring.coreos.com
       description: Prometheus defines a Prometheus deployment.
     - kind: PrometheusRule
-      version: v1
+      version: monitoring.coreos.com/v1
       name: prometheusrules.monitoring.coreos.com
       description: PrometheusRule defines recording and alerting rules for a Prometheus
     - kind: ThanosRuler
-      version: v1
+      version: monitoring.coreos.com/v1
       name: thanosrulers.monitoring.coreos.com
       description: ThanosRuler defines a ThanosRuler deployment.
     - kind: ServiceMonitor
-      version: v1
+      version: monitoring.coreos.com/v1
       name: servicemonitors.monitoring.coreos.com
       description: ServiceMonitor defines monitoring for a set of services.
+  artifacthub.io/crdsExamples: |
+    - apiVersion: monitoring.coreos.com/v1
+      kind: ServiceMonitor
+      metadata:
+        name: example-app
+        labels:
+          team: frontend
+      spec:
+        selector:
+          matchLabels:
+            app: example-app
+        endpoints:
+        - port: web
+    - apiVersion: monitoring.coreos.com/v1
+      kind: Prometheus
+      metadata:
+        name: prometheus
+      spec:
+        serviceAccountName: prometheus
+        serviceMonitorSelector:
+          matchLabels:
+            team: frontend
+        resources:
+          requests:
+            memory: 400Mi
+        enableAdminAPI: false
+    - apiVersion: monitoring.coreos.com/v1
+      kind: Alertmanager
+      metadata:
+        name: main
+      spec:
+        replicas: 3
+        resources:
+          requests:
+            memory: 400Mi
+    - apiVersion: monitoring.coreos.com/v1alpha1
+      kind: AlertmanagerConfig
+      metadata:
+        name: config-example
+        labels:
+          alertmanagerConfig: example
+      spec:
+        route:
+          groupBy: ['job']
+          groupWait: 30s
+          groupInterval: 5m
+          repeatInterval: 12h
+          receiver: 'wechat-example'
+        receivers:
+        - name: 'wechat-example'
+          wechatConfigs:
+          - apiURL: 'http://wechatserver:8080/'
+            corpID: 'wechat-corpid'
+            apiSecret:
+              name: 'wechat-config'
+              key: 'apiSecret'
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        creationTimestamp: null
+        labels:
+          prometheus: example
+          role: alert-rules
+        name: prometheus-example-rules
+      spec:
+        groups:
+        - name: ./example.rules
+          rules:
+          - alert: ExampleAlert
+            expr: vector(1)
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PodMonitor
+      metadata:
+        name: example-app
+      spec:
+        selector:
+          matchLabels:
+            app: example-app
+        podMetricsEndpoints:
+        - port: web
+        namespaceSelector:
+          any: true
+    - apiVersion: monitoring.coreos.com/v1
+      kind: ThanosRuler
+      metadata:
+        name: thanos-ruler-demo
+        labels:
+          example: thanos-ruler
+        namespace: monitoring
+      spec:
+        image: quay.io/thanos/thanos
+        ruleSelector:
+          matchLabels:
+            role: my-thanos-rules
+        queryEndpoints:
+          - dnssrv+_http._tcp.my-thanos-querier.monitoring.svc.cluster.local
   artifacthub.io/recommendations: |
     - url: https://artifacthub.io/packages/helm/artifact-hub/artifact-hub
     - url: https://artifacthub.io/packages/helm/prometheus-community/kube-prometheus-stack

--- a/charts/prometheus-operator/Chart.yaml
+++ b/charts/prometheus-operator/Chart.yaml
@@ -5,9 +5,9 @@ description: Stripped down version of prometheus-operator to only provision the 
 
 type: application
 
-version: 0.1.2
+version: 1.0.0-rc1
 
-appVersion: "0.58.0"
+appVersion: 0.59.1
 
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/arldka/helm-charts
@@ -18,10 +18,10 @@ keywords:
 annotations:
   artifacthub.io/operator: "true"
   artifacthub.io/operatorCapabilities: Deep Insights
-  artifacthub.io/prerelease: "false"
+  artifacthub.io/prerelease: "true"
   artifacthub.io/changes: |
-    - kind: fixed
-      description: Removed the remaining if .Values.enanbled
+    - kind: changed
+      description: Updates the Chart's crds and values for prometheus-operator 0.59.1
   artifacthub.io/links: |
     - name: Chart source
       url: https://github.com/arldka/helm-charts       
@@ -65,5 +65,3 @@ annotations:
   artifacthub.io/recommendations: |
     - url: https://artifacthub.io/packages/helm/artifact-hub/artifact-hub
     - url: https://artifacthub.io/packages/helm/prometheus-community/kube-prometheus-stack
-
-

--- a/charts/prometheus-operator/Chart.yaml
+++ b/charts/prometheus-operator/Chart.yaml
@@ -22,6 +22,14 @@ annotations:
   artifacthub.io/changes: |
     - kind: changed
       description: Updates the Chart's crds and values for prometheus-operator 0.59.1
+      links:
+        - name: Github PR
+          url: https://github.com/arldka/helm-charts/pull/3
+    - kind: added
+      description: Added ArgoCD SyncOption annotations to use kubectl replace for crds
+      links:
+        - name: Github PR
+          url: https://github.com/arldka/helm-charts/pull/3
   artifacthub.io/links: |
     - name: Chart source
       url: https://github.com/arldka/helm-charts       

--- a/charts/prometheus-operator/README.md
+++ b/charts/prometheus-operator/README.md
@@ -73,7 +73,7 @@ A major chart version change (like v1.2.3 -> v2.0.0) indicates that there is an 
 
 This version upgrades Prometheus-Operator to v0.59.1.
 
-Run these commands to update the CRDs before applying the upgrade.
+Run these commands to update the CRDs before applying the upgrade if you are not using ArgoCD to deploy the operator.
 
 ```console
 kubectl apply --server-side -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.59.1/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml
@@ -145,7 +145,7 @@ Because the operator can only run as a single pod, there is potential for this c
 | admissionWebhooks.patch.image.pullPolicy | string | `"IfNotPresent"` |  |
 | admissionWebhooks.patch.image.repository | string | `"k8s.gcr.io/ingress-nginx/kube-webhook-certgen"` |  |
 | admissionWebhooks.patch.image.sha | string | `""` |  |
-| admissionWebhooks.patch.image.tag | string | `"v1.2.0"` |  |
+| admissionWebhooks.patch.image.tag | string | `"v1.3.0"` |  |
 | admissionWebhooks.patch.nodeSelector | object | `{}` |  |
 | admissionWebhooks.patch.podAnnotations | object | `{}` |  |
 | admissionWebhooks.patch.priorityClassName | string | `""` |  |
@@ -175,7 +175,7 @@ Because the operator can only run as a single pod, there is potential for this c
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"quay.io/prometheus-operator/prometheus-operator"` |  |
 | image.sha | string | `""` |  |
-| image.tag | string | `"v0.58.0"` |  |
+| image.tag | string | `"v0.59.1"` |  |
 | kubeTargetVersionOverride | string | `""` |  |
 | kubeVersionOverride | string | `""` |  |
 | kubeletService.enabled | bool | `true` |  |
@@ -189,7 +189,7 @@ Because the operator can only run as a single pod, there is potential for this c
 | podLabels | object | `{}` |  |
 | prometheusConfigReloader.image.repository | string | `"quay.io/prometheus-operator/prometheus-config-reloader"` |  |
 | prometheusConfigReloader.image.sha | string | `""` |  |
-| prometheusConfigReloader.image.tag | string | `"v0.58.0"` |  |
+| prometheusConfigReloader.image.tag | string | `"v0.59.1"` |  |
 | prometheusConfigReloader.resources.limits.cpu | string | `"200m"` |  |
 | prometheusConfigReloader.resources.limits.memory | string | `"50Mi"` |  |
 | prometheusConfigReloader.resources.requests.cpu | string | `"200m"` |  |
@@ -221,7 +221,7 @@ Because the operator can only run as a single pod, there is potential for this c
 | serviceMonitor.selfMonitor | bool | `true` |  |
 | thanosImage.repository | string | `"quay.io/thanos/thanos"` |  |
 | thanosImage.sha | string | `""` |  |
-| thanosImage.tag | string | `"v0.27.0"` |  |
+| thanosImage.tag | string | `"v0.28.0"` |  |
 | thanosRulerInstanceNamespaces | list | `[]` |  |
 | tls.enabled | bool | `true` |  |
 | tls.internalPort | int | `10250` |  |
@@ -254,7 +254,7 @@ Kubernetes: `>=1.16.0-0`
 | admissionWebhooks.patch.image.pullPolicy | string | `"IfNotPresent"` |  |
 | admissionWebhooks.patch.image.repository | string | `"k8s.gcr.io/ingress-nginx/kube-webhook-certgen"` |  |
 | admissionWebhooks.patch.image.sha | string | `""` |  |
-| admissionWebhooks.patch.image.tag | string | `"v1.2.0"` |  |
+| admissionWebhooks.patch.image.tag | string | `"v1.3.0"` |  |
 | admissionWebhooks.patch.nodeSelector | object | `{}` |  |
 | admissionWebhooks.patch.podAnnotations | object | `{}` |  |
 | admissionWebhooks.patch.priorityClassName | string | `""` |  |
@@ -284,7 +284,7 @@ Kubernetes: `>=1.16.0-0`
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"quay.io/prometheus-operator/prometheus-operator"` |  |
 | image.sha | string | `""` |  |
-| image.tag | string | `"v0.58.0"` |  |
+| image.tag | string | `"v0.59.1"` |  |
 | kubeTargetVersionOverride | string | `""` |  |
 | kubeVersionOverride | string | `""` |  |
 | kubeletService.enabled | bool | `true` |  |
@@ -298,7 +298,7 @@ Kubernetes: `>=1.16.0-0`
 | podLabels | object | `{}` |  |
 | prometheusConfigReloader.image.repository | string | `"quay.io/prometheus-operator/prometheus-config-reloader"` |  |
 | prometheusConfigReloader.image.sha | string | `""` |  |
-| prometheusConfigReloader.image.tag | string | `"v0.58.0"` |  |
+| prometheusConfigReloader.image.tag | string | `"v0.59.1"` |  |
 | prometheusConfigReloader.resources.limits.cpu | string | `"200m"` |  |
 | prometheusConfigReloader.resources.limits.memory | string | `"50Mi"` |  |
 | prometheusConfigReloader.resources.requests.cpu | string | `"200m"` |  |
@@ -330,7 +330,7 @@ Kubernetes: `>=1.16.0-0`
 | serviceMonitor.selfMonitor | bool | `true` |  |
 | thanosImage.repository | string | `"quay.io/thanos/thanos"` |  |
 | thanosImage.sha | string | `""` |  |
-| thanosImage.tag | string | `"v0.27.0"` |  |
+| thanosImage.tag | string | `"v0.28.0"` |  |
 | thanosRulerInstanceNamespaces | list | `[]` |  |
 | tls.enabled | bool | `true` |  |
 | tls.internalPort | int | `10250` |  |

--- a/charts/prometheus-operator/README.md
+++ b/charts/prometheus-operator/README.md
@@ -1,6 +1,6 @@
 # Prometheus Operator Chart
 
-![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.58.0](https://img.shields.io/badge/AppVersion-0.58.0-informational?style=flat-square)
+![Version: 1.0.0-rc1](https://img.shields.io/badge/Version-1.0.0--rc1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.59.1](https://img.shields.io/badge/AppVersion-0.59.1-informational?style=flat-square)
 
 ## Description
 
@@ -68,6 +68,23 @@ _See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documen
 ### Upgrading an existing Release to a new major version
 
 A major chart version change (like v1.2.3 -> v2.0.0) indicates that there is an incompatible breaking change needing manual actions.
+
+### From 0.x to 1.x
+
+This version upgrades Prometheus-Operator to v0.59.1.
+
+Run these commands to update the CRDs before applying the upgrade.
+
+```console
+kubectl apply --server-side -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.59.1/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml
+kubectl apply --server-side -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.59.1/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
+kubectl apply --server-side -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.59.1/example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml
+kubectl apply --server-side -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.59.1/example/prometheus-operator-crd/monitoring.coreos.com_probes.yaml
+kubectl apply --server-side -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.59.1/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
+kubectl apply --server-side -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.59.1/example/prometheus-operator-crd/monitoring.coreos.com_prometheusrules.yaml
+kubectl apply --server-side -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.59.1/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml
+kubectl apply --server-side -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.59.1/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
+```
 
 ## Configuration
 
@@ -209,4 +226,116 @@ Because the operator can only run as a single pod, there is potential for this c
 | tls.enabled | bool | `true` |  |
 | tls.internalPort | int | `10250` |  |
 | tls.tlsMinVersion | string | `"VersionTLS13"` |  |
+| tolerations | list | `[]` |  |# prometheus-operator
+
+![Version: 1.0.0-rc1](https://img.shields.io/badge/Version-1.0.0--rc1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.59.1](https://img.shields.io/badge/AppVersion-0.59.1-informational?style=flat-square)
+
+Stripped down version of prometheus-operator to only provision the operator and nothing else based on the kube-prometheus-stack chart.
+
+**Homepage:** <https://github.com/arldka/helm-charts>
+
+## Requirements
+
+Kubernetes: `>=1.16.0-0`
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| admissionWebhooks.caBundle | string | `""` |  |
+| admissionWebhooks.certManager.admissionCert.duration | string | `""` |  |
+| admissionWebhooks.certManager.enabled | bool | `false` |  |
+| admissionWebhooks.certManager.rootCert.duration | string | `""` |  |
+| admissionWebhooks.createSecretJob.securityContext | object | `{}` |  |
+| admissionWebhooks.enabled | bool | `true` |  |
+| admissionWebhooks.failurePolicy | string | `"Fail"` |  |
+| admissionWebhooks.patch.affinity | object | `{}` |  |
+| admissionWebhooks.patch.enabled | bool | `true` |  |
+| admissionWebhooks.patch.image.pullPolicy | string | `"IfNotPresent"` |  |
+| admissionWebhooks.patch.image.repository | string | `"k8s.gcr.io/ingress-nginx/kube-webhook-certgen"` |  |
+| admissionWebhooks.patch.image.sha | string | `""` |  |
+| admissionWebhooks.patch.image.tag | string | `"v1.2.0"` |  |
+| admissionWebhooks.patch.nodeSelector | object | `{}` |  |
+| admissionWebhooks.patch.podAnnotations | object | `{}` |  |
+| admissionWebhooks.patch.priorityClassName | string | `""` |  |
+| admissionWebhooks.patch.resources | object | `{}` |  |
+| admissionWebhooks.patch.securityContext.runAsGroup | int | `2000` |  |
+| admissionWebhooks.patch.securityContext.runAsNonRoot | bool | `true` |  |
+| admissionWebhooks.patch.securityContext.runAsUser | int | `2000` |  |
+| admissionWebhooks.patch.tolerations | list | `[]` |  |
+| admissionWebhooks.patchWebhookJob.securityContext | object | `{}` |  |
+| admissionWebhooks.timeoutSeconds | int | `10` |  |
+| affinity | object | `{}` |  |
+| alertmanagerConfigNamespaces | list | `[]` |  |
+| alertmanagerInstanceNamespaces | list | `[]` |  |
+| annotations | object | `{}` |  |
+| commonLabels | object | `{}` |  |
+| containerSecurityContext.allowPrivilegeEscalation | bool | `false` |  |
+| containerSecurityContext.readOnlyRootFilesystem | bool | `true` |  |
+| denyNamespaces | list | `[]` |  |
+| dnsConfig | object | `{}` |  |
+| fullnameOverride | string | `""` |  |
+| global.imagePullSecrets | list | `[]` |  |
+| global.rbac.create | bool | `true` |  |
+| global.rbac.createAggregateClusterRoles | bool | `false` |  |
+| global.rbac.pspAnnotations | object | `{}` |  |
+| global.rbac.pspEnabled | bool | `false` |  |
+| hostNetwork | bool | `false` |  |
+| image.pullPolicy | string | `"IfNotPresent"` |  |
+| image.repository | string | `"quay.io/prometheus-operator/prometheus-operator"` |  |
+| image.sha | string | `""` |  |
+| image.tag | string | `"v0.58.0"` |  |
+| kubeTargetVersionOverride | string | `""` |  |
+| kubeVersionOverride | string | `""` |  |
+| kubeletService.enabled | bool | `true` |  |
+| kubeletService.name | string | `""` |  |
+| kubeletService.namespace | string | `"kube-system"` |  |
+| nameOverride | string | `""` |  |
+| namespaceOverride | string | `""` |  |
+| namespaces | object | `{}` |  |
+| nodeSelector | object | `{}` |  |
+| podAnnotations | object | `{}` |  |
+| podLabels | object | `{}` |  |
+| prometheusConfigReloader.image.repository | string | `"quay.io/prometheus-operator/prometheus-config-reloader"` |  |
+| prometheusConfigReloader.image.sha | string | `""` |  |
+| prometheusConfigReloader.image.tag | string | `"v0.58.0"` |  |
+| prometheusConfigReloader.resources.limits.cpu | string | `"200m"` |  |
+| prometheusConfigReloader.resources.limits.memory | string | `"50Mi"` |  |
+| prometheusConfigReloader.resources.requests.cpu | string | `"200m"` |  |
+| prometheusConfigReloader.resources.requests.memory | string | `"50Mi"` |  |
+| prometheusInstanceNamespaces | list | `[]` |  |
+| resources | object | `{}` |  |
+| secretFieldSelector | string | `""` |  |
+| securityContext.fsGroup | int | `65534` |  |
+| securityContext.runAsGroup | int | `65534` |  |
+| securityContext.runAsNonRoot | bool | `true` |  |
+| securityContext.runAsUser | int | `65534` |  |
+| service.additionalPorts | list | `[]` |  |
+| service.annotations | object | `{}` |  |
+| service.clusterIP | string | `""` |  |
+| service.externalIPs | list | `[]` |  |
+| service.externalTrafficPolicy | string | `"Cluster"` |  |
+| service.labels | object | `{}` |  |
+| service.loadBalancerIP | string | `""` |  |
+| service.loadBalancerSourceRanges | list | `[]` |  |
+| service.nodePort | int | `30080` |  |
+| service.nodePortTls | int | `30443` |  |
+| service.type | string | `"ClusterIP"` |  |
+| serviceAccount.create | bool | `true` |  |
+| serviceAccount.name | string | `""` |  |
+| serviceMonitor.interval | string | `""` |  |
+| serviceMonitor.metricRelabelings | list | `[]` |  |
+| serviceMonitor.relabelings | list | `[]` |  |
+| serviceMonitor.scrapeTimeout | string | `""` |  |
+| serviceMonitor.selfMonitor | bool | `true` |  |
+| thanosImage.repository | string | `"quay.io/thanos/thanos"` |  |
+| thanosImage.sha | string | `""` |  |
+| thanosImage.tag | string | `"v0.27.0"` |  |
+| thanosRulerInstanceNamespaces | list | `[]` |  |
+| tls.enabled | bool | `true` |  |
+| tls.internalPort | int | `10250` |  |
+| tls.tlsMinVersion | string | `"VersionTLS13"` |  |
 | tolerations | list | `[]` |  |
+
+----------------------------------------------
+Autogenerated from chart metadata using [helm-docs v1.11.0](https://github.com/norwoodj/helm-docs/releases/v1.11.0)

--- a/charts/prometheus-operator/README.md.gotmpl
+++ b/charts/prometheus-operator/README.md.gotmpl
@@ -72,7 +72,7 @@ A major chart version change (like v1.2.3 -> v2.0.0) indicates that there is an 
 
 This version upgrades Prometheus-Operator to v0.59.1. 
 
-Run these commands to update the CRDs before applying the upgrade.
+Run these commands to update the CRDs before applying the upgrade if you are not using ArgoCD to deploy the operator.
 
 ```console
 kubectl apply --server-side -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.59.1/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml

--- a/charts/prometheus-operator/README.md.gotmpl
+++ b/charts/prometheus-operator/README.md.gotmpl
@@ -68,6 +68,23 @@ _See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documen
 
 A major chart version change (like v1.2.3 -> v2.0.0) indicates that there is an incompatible breaking change needing manual actions.
 
+### From 0.x to 1.x
+
+This version upgrades Prometheus-Operator to v0.59.1. 
+
+Run these commands to update the CRDs before applying the upgrade.
+
+```console
+kubectl apply --server-side -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.59.1/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml
+kubectl apply --server-side -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.59.1/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
+kubectl apply --server-side -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.59.1/example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml
+kubectl apply --server-side -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.59.1/example/prometheus-operator-crd/monitoring.coreos.com_probes.yaml
+kubectl apply --server-side -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.59.1/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
+kubectl apply --server-side -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.59.1/example/prometheus-operator-crd/monitoring.coreos.com_prometheusrules.yaml
+kubectl apply --server-side -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.59.1/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml
+kubectl apply --server-side -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.59.1/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
+```
+
 ## Configuration
 
 See [Customizing the Chart Before Installing](https://helm.sh/docs/intro/using_helm/#customizing-the-chart-before-installing). To see all configurable options with detailed comments:

--- a/charts/prometheus-operator/crds/crd-alertmanagerconfigs.yaml
+++ b/charts/prometheus-operator/crds/crd-alertmanagerconfigs.yaml
@@ -1,4 +1,4 @@
-# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.58.0/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml
+# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.59.1/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/charts/prometheus-operator/crds/crd-alertmanagerconfigs.yaml
+++ b/charts/prometheus-operator/crds/crd-alertmanagerconfigs.yaml
@@ -5,6 +5,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.2
+    argocd.argoproj.io/sync-options: Replace=true
   creationTimestamp: null
   name: alertmanagerconfigs.monitoring.coreos.com
 spec:

--- a/charts/prometheus-operator/crds/crd-alertmanagers.yaml
+++ b/charts/prometheus-operator/crds/crd-alertmanagers.yaml
@@ -1,4 +1,4 @@
-# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.58.0/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
+# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.59.1/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -981,15 +981,365 @@ spec:
                 x-kubernetes-map-type: atomic
               alertmanagerConfiguration:
                 description: 'EXPERIMENTAL: alertmanagerConfiguration specifies the
-                  global Alertmanager configuration. If defined, it takes precedence
-                  over the `configSecret` field. This field may change in future releases.'
+                  configuration of Alertmanager. If defined, it takes precedence over
+                  the `configSecret` field. This field may change in future releases.'
                 properties:
+                  global:
+                    description: Defines the global parameters of the Alertmanager
+                      configuration.
+                    properties:
+                      httpConfig:
+                        description: HTTP client configuration.
+                        properties:
+                          authorization:
+                            description: Authorization header configuration for the
+                              client. This is mutually exclusive with BasicAuth and
+                              is only available starting from Alertmanager v0.22+.
+                            properties:
+                              credentials:
+                                description: The secret's key that contains the credentials
+                                  of the request
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its
+                                      key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              type:
+                                description: Set the authentication type. Defaults
+                                  to Bearer, Basic will cause an error
+                                type: string
+                            type: object
+                          basicAuth:
+                            description: BasicAuth for the client. This is mutually
+                              exclusive with Authorization. If both are defined, BasicAuth
+                              takes precedence.
+                            properties:
+                              password:
+                                description: The secret in the service monitor namespace
+                                  that contains the password for authentication.
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its
+                                      key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              username:
+                                description: The secret in the service monitor namespace
+                                  that contains the username for authentication.
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its
+                                      key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            type: object
+                          bearerTokenSecret:
+                            description: The secret's key that contains the bearer
+                              token to be used by the client for authentication. The
+                              secret needs to be in the same namespace as the Alertmanager
+                              object and accessible by the Prometheus Operator.
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          followRedirects:
+                            description: FollowRedirects specifies whether the client
+                              should follow HTTP 3xx redirects.
+                            type: boolean
+                          oauth2:
+                            description: OAuth2 client credentials used to fetch a
+                              token for the targets.
+                            properties:
+                              clientId:
+                                description: The secret or configmap containing the
+                                  OAuth2 client id
+                                properties:
+                                  configMap:
+                                    description: ConfigMap containing data to use
+                                      for the targets.
+                                    properties:
+                                      key:
+                                        description: The key to select.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap
+                                          or its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  secret:
+                                    description: Secret containing data to use for
+                                      the targets.
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                type: object
+                              clientSecret:
+                                description: The secret containing the OAuth2 client
+                                  secret
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its
+                                      key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              endpointParams:
+                                additionalProperties:
+                                  type: string
+                                description: Parameters to append to the token URL
+                                type: object
+                              scopes:
+                                description: OAuth2 scopes used for the token request
+                                items:
+                                  type: string
+                                type: array
+                              tokenUrl:
+                                description: The URL to fetch the token from
+                                minLength: 1
+                                type: string
+                            required:
+                            - clientId
+                            - clientSecret
+                            - tokenUrl
+                            type: object
+                          proxyURL:
+                            description: Optional proxy URL.
+                            type: string
+                          tlsConfig:
+                            description: TLS configuration for the client.
+                            properties:
+                              ca:
+                                description: Struct containing the CA cert to use
+                                  for the targets.
+                                properties:
+                                  configMap:
+                                    description: ConfigMap containing data to use
+                                      for the targets.
+                                    properties:
+                                      key:
+                                        description: The key to select.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap
+                                          or its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  secret:
+                                    description: Secret containing data to use for
+                                      the targets.
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                type: object
+                              cert:
+                                description: Struct containing the client cert file
+                                  for the targets.
+                                properties:
+                                  configMap:
+                                    description: ConfigMap containing data to use
+                                      for the targets.
+                                    properties:
+                                      key:
+                                        description: The key to select.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap
+                                          or its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  secret:
+                                    description: Secret containing data to use for
+                                      the targets.
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                type: object
+                              insecureSkipVerify:
+                                description: Disable target certificate validation.
+                                type: boolean
+                              keySecret:
+                                description: Secret containing the client key file
+                                  for the targets.
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its
+                                      key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              serverName:
+                                description: Used to verify the hostname for the targets.
+                                type: string
+                            type: object
+                        type: object
+                      resolveTimeout:
+                        description: ResolveTimeout is the default value used by alertmanager
+                          if the alert does not include EndsAt, after this time passes
+                          it can declare the alert as resolved if it has not been
+                          updated. This has no impact on alerts from Prometheus, as
+                          they always include EndsAt.
+                        pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
+                        type: string
+                    type: object
                   name:
                     description: The name of the AlertmanagerConfig resource which
-                      is used to generate the global configuration. It must be defined
-                      in the same namespace as the Alertmanager object. The operator
-                      will not enforce a `namespace` label for routes and inhibition
-                      rules.
+                      is used to generate the Alertmanager configuration. It must
+                      be defined in the same namespace as the Alertmanager object.
+                      The operator will not enforce a `namespace` label for routes
+                      and inhibition rules.
                     minLength: 1
                     type: string
                 type: object
@@ -1595,13 +1945,13 @@ spec:
                         Cannot be updated.
                       type: string
                     ports:
-                      description: List of ports to expose from the container. Exposing
-                        a port here gives the system additional information about
-                        the network connections a container uses, but is primarily
-                        informational. Not specifying a port here DOES NOT prevent
-                        that port from being exposed. Any port which is listening
-                        on the default "0.0.0.0" address inside a container will be
-                        accessible from the network. Cannot be updated.
+                      description: List of ports to expose from the container. Not
+                        specifying a port here DOES NOT prevent that port from being
+                        exposed. Any port which is listening on the default "0.0.0.0"
+                        address inside a container will be accessible from the network.
+                        Modifying this array with strategic merge patch may corrupt
+                        the data. For more information See https://github.com/kubernetes/kubernetes/issues/108255.
+                        Cannot be updated.
                       items:
                         description: ContainerPort represents a network port in a
                           single container.
@@ -2880,13 +3230,13 @@ spec:
                         Cannot be updated.
                       type: string
                     ports:
-                      description: List of ports to expose from the container. Exposing
-                        a port here gives the system additional information about
-                        the network connections a container uses, but is primarily
-                        informational. Not specifying a port here DOES NOT prevent
-                        that port from being exposed. Any port which is listening
-                        on the default "0.0.0.0" address inside a container will be
-                        accessible from the network. Cannot be updated.
+                      description: List of ports to expose from the container. Not
+                        specifying a port here DOES NOT prevent that port from being
+                        exposed. Any port which is listening on the default "0.0.0.0"
+                        address inside a container will be accessible from the network.
+                        Modifying this array with strategic merge patch may corrupt
+                        the data. For more information See https://github.com/kubernetes/kubernetes/issues/108255.
+                        Cannot be updated.
                       items:
                         description: ContainerPort represents a network port in a
                           single container.
@@ -4509,6 +4859,19 @@ spec:
                           type: object
                       type: object
                       x-kubernetes-map-type: atomic
+                    matchLabelKeys:
+                      description: MatchLabelKeys is a set of pod label keys to select
+                        the pods over which spreading will be calculated. The keys
+                        are used to lookup values from the incoming pod labels, those
+                        key-value labels are ANDed with labelSelector to select the
+                        group of existing pods over which spreading will be calculated
+                        for the incoming pod. Keys that don't exist in the incoming
+                        pod labels will be ignored. A null or empty list means only
+                        match against labelSelector.
+                      items:
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: atomic
                     maxSkew:
                       description: 'MaxSkew describes the degree to which pods may
                         be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
@@ -4549,11 +4912,31 @@ spec:
                         minimum\" is treated as 0. In this situation, new pod with
                         the same labelSelector cannot be scheduled, because computed
                         skew will be 3(3 - 0) if new Pod is scheduled to any of the
-                        three zones, it will violate MaxSkew. \n This is an alpha
-                        field and requires enabling MinDomainsInPodTopologySpread
-                        feature gate."
+                        three zones, it will violate MaxSkew. \n This is a beta field
+                        and requires the MinDomainsInPodTopologySpread feature gate
+                        to be enabled (enabled by default)."
                       format: int32
                       type: integer
+                    nodeAffinityPolicy:
+                      description: "NodeAffinityPolicy indicates how we will treat
+                        Pod's nodeAffinity/nodeSelector when calculating pod topology
+                        spread skew. Options are: - Honor: only nodes matching nodeAffinity/nodeSelector
+                        are included in the calculations. - Ignore: nodeAffinity/nodeSelector
+                        are ignored. All nodes are included in the calculations. \n
+                        If this value is nil, the behavior is equivalent to the Honor
+                        policy. This is a alpha-level feature enabled by the NodeInclusionPolicyInPodTopologySpread
+                        feature flag."
+                      type: string
+                    nodeTaintsPolicy:
+                      description: "NodeTaintsPolicy indicates how we will treat node
+                        taints when calculating pod topology spread skew. Options
+                        are: - Honor: nodes without taints, along with tainted nodes
+                        for which the incoming pod has a toleration, are included.
+                        - Ignore: node taints are ignored. All nodes are included.
+                        \n If this value is nil, the behavior is equivalent to the
+                        Ignore policy. This is a alpha-level feature enabled by the
+                        NodeInclusionPolicyInPodTopologySpread feature flag."
+                      type: string
                     topologyKey:
                       description: TopologyKey is the key of node labels. Nodes that
                         have a label with this key and identical values are considered
@@ -4561,10 +4944,11 @@ spec:
                         as a "bucket", and try to put balanced number of pods into
                         each bucket. We define a domain as a particular instance of
                         a topology. Also, we define an eligible domain as a domain
-                        whose nodes match the node selector. e.g. If TopologyKey is
-                        "kubernetes.io/hostname", each Node is a domain of that topology.
-                        And, if TopologyKey is "topology.kubernetes.io/zone", each
-                        zone is a domain of that topology. It's a required field.
+                        whose nodes meet the requirements of nodeAffinityPolicy and
+                        nodeTaintsPolicy. e.g. If TopologyKey is "kubernetes.io/hostname",
+                        each Node is a domain of that topology. And, if TopologyKey
+                        is "topology.kubernetes.io/zone", each zone is a domain of
+                        that topology. It's a required field.
                       type: string
                     whenUnsatisfiable:
                       description: 'WhenUnsatisfiable indicates how to deal with a
@@ -6153,8 +6537,55 @@ spec:
               web:
                 description: Defines the web command line flags when starting Alertmanager.
                 properties:
+                  httpConfig:
+                    description: Defines HTTP parameters for web server.
+                    properties:
+                      headers:
+                        description: List of headers that can be added to HTTP responses.
+                        properties:
+                          contentSecurityPolicy:
+                            description: Set the Content-Security-Policy header to
+                              HTTP responses. Unset if blank.
+                            type: string
+                          strictTransportSecurity:
+                            description: Set the Strict-Transport-Security header
+                              to HTTP responses. Unset if blank. Please make sure
+                              that you use this with care as this header might force
+                              browsers to load Prometheus and the other applications
+                              hosted on the same domain and subdomains over HTTPS.
+                              https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security
+                            type: string
+                          xContentTypeOptions:
+                            description: Set the X-Content-Type-Options header to
+                              HTTP responses. Unset if blank. Accepted value is nosniff.
+                              https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Content-Type-Options
+                            enum:
+                            - ""
+                            - NoSniff
+                            type: string
+                          xFrameOptions:
+                            description: Set the X-Frame-Options header to HTTP responses.
+                              Unset if blank. Accepted values are deny and sameorigin.
+                              https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options
+                            enum:
+                            - ""
+                            - Deny
+                            - SameOrigin
+                            type: string
+                          xXSSProtection:
+                            description: Set the X-XSS-Protection header to all responses.
+                              Unset if blank. https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection
+                            type: string
+                        type: object
+                      http2:
+                        description: Enable HTTP/2 support. Note that HTTP/2 is only
+                          supported with TLS. When TLSConfig is not configured, HTTP/2
+                          will be disabled. Whenever the value of the field changes,
+                          a rolling update will be triggered.
+                        type: boolean
+                    type: object
                   tlsConfig:
-                    description: WebTLSConfig defines the TLS parameters for HTTPS.
+                    description: Defines the TLS parameters for HTTPS.
                     properties:
                       cert:
                         description: Contains the TLS certificate for the server.

--- a/charts/prometheus-operator/crds/crd-alertmanagers.yaml
+++ b/charts/prometheus-operator/crds/crd-alertmanagers.yaml
@@ -5,6 +5,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.2
+    argocd.argoproj.io/sync-options: Replace=true
   creationTimestamp: null
   name: alertmanagers.monitoring.coreos.com
 spec:

--- a/charts/prometheus-operator/crds/crd-podmonitors.yaml
+++ b/charts/prometheus-operator/crds/crd-podmonitors.yaml
@@ -1,4 +1,4 @@
-# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.58.0/example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml
+# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.59.1/example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/charts/prometheus-operator/crds/crd-podmonitors.yaml
+++ b/charts/prometheus-operator/crds/crd-podmonitors.yaml
@@ -5,6 +5,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.2
+    argocd.argoproj.io/sync-options: Replace=true
   creationTimestamp: null
   name: podmonitors.monitoring.coreos.com
 spec:

--- a/charts/prometheus-operator/crds/crd-probes.yaml
+++ b/charts/prometheus-operator/crds/crd-probes.yaml
@@ -1,4 +1,4 @@
-# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.58.0/example/prometheus-operator-crd/monitoring.coreos.com_probes.yaml
+# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.59.1/example/prometheus-operator-crd/monitoring.coreos.com_probes.yaml
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/charts/prometheus-operator/crds/crd-probes.yaml
+++ b/charts/prometheus-operator/crds/crd-probes.yaml
@@ -5,6 +5,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.2
+    argocd.argoproj.io/sync-options: Replace=true
   creationTimestamp: null
   name: probes.monitoring.coreos.com
 spec:

--- a/charts/prometheus-operator/crds/crd-prometheuses.yaml
+++ b/charts/prometheus-operator/crds/crd-prometheuses.yaml
@@ -1,4 +1,4 @@
-# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.58.0/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
+# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.59.1/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -109,6 +109,31 @@ spec:
                 - key
                 type: object
                 x-kubernetes-map-type: atomic
+              additionalArgs:
+                description: AdditionalArgs allows setting additional arguments for
+                  the Prometheus container. It is intended for e.g. activating hidden
+                  flags which are not supported by the dedicated configuration options
+                  yet. The arguments are passed as-is to the Prometheus container
+                  which may cause issues if they are invalid or not supporeted by
+                  the given Prometheus version. In case of an argument conflict (e.g.
+                  an argument which is already set by the operator itself) or when
+                  providing an invalid argument the reconciliation will fail and an
+                  error will be logged.
+                items:
+                  description: Argument as part of the AdditionalArgs list.
+                  properties:
+                    name:
+                      description: Name of the argument, e.g. "scrape.discovery-reload-interval".
+                      minLength: 1
+                      type: string
+                    value:
+                      description: Argument value, e.g. 30s. Can be empty for name-only
+                        arguments (e.g. --storage.tsdb.no-lockfile)
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
               additionalScrapeConfigs:
                 description: 'AdditionalScrapeConfigs allows specifying a key of a
                   Secret containing additional Prometheus scrape configurations. Scrape
@@ -2003,13 +2028,13 @@ spec:
                         Cannot be updated.
                       type: string
                     ports:
-                      description: List of ports to expose from the container. Exposing
-                        a port here gives the system additional information about
-                        the network connections a container uses, but is primarily
-                        informational. Not specifying a port here DOES NOT prevent
-                        that port from being exposed. Any port which is listening
-                        on the default "0.0.0.0" address inside a container will be
-                        accessible from the network. Cannot be updated.
+                      description: List of ports to expose from the container. Not
+                        specifying a port here DOES NOT prevent that port from being
+                        exposed. Any port which is listening on the default "0.0.0.0"
+                        address inside a container will be accessible from the network.
+                        Modifying this array with strategic merge patch may corrupt
+                        the data. For more information See https://github.com/kubernetes/kubernetes/issues/108255.
+                        Cannot be updated.
                       items:
                         description: ContainerPort represents a network port in a
                           single container.
@@ -3439,13 +3464,13 @@ spec:
                         Cannot be updated.
                       type: string
                     ports:
-                      description: List of ports to expose from the container. Exposing
-                        a port here gives the system additional information about
-                        the network connections a container uses, but is primarily
-                        informational. Not specifying a port here DOES NOT prevent
-                        that port from being exposed. Any port which is listening
-                        on the default "0.0.0.0" address inside a container will be
-                        accessible from the network. Cannot be updated.
+                      description: List of ports to expose from the container. Not
+                        specifying a port here DOES NOT prevent that port from being
+                        exposed. Any port which is listening on the default "0.0.0.0"
+                        address inside a container will be accessible from the network.
+                        Modifying this array with strategic merge patch may corrupt
+                        the data. For more information See https://github.com/kubernetes/kubernetes/issues/108255.
+                        Cannot be updated.
                       items:
                         description: ContainerPort represents a network port in a
                           single container.
@@ -6346,6 +6371,29 @@ spec:
                   notice in any release. \n This is experimental and may change significantly
                   without backward compatibility in any release."
                 properties:
+                  additionalArgs:
+                    description: AdditionalArgs allows setting additional arguments
+                      for the Thanos container. The arguments are passed as-is to
+                      the Thanos container which may cause issues if they are invalid
+                      or not supporeted the given Thanos version. In case of an argument
+                      conflict (e.g. an argument which is already set by the operator
+                      itself) or when providing an invalid argument the reconciliation
+                      will fail and an error will be logged.
+                    items:
+                      description: Argument as part of the AdditionalArgs list.
+                      properties:
+                        name:
+                          description: Name of the argument, e.g. "scrape.discovery-reload-interval".
+                          minLength: 1
+                          type: string
+                        value:
+                          description: Argument value, e.g. 30s. Can be empty for
+                            name-only arguments (e.g. --storage.tsdb.no-lockfile)
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
                   baseImage:
                     description: 'Thanos base image if other than default. Deprecated:
                       use ''image'' instead'
@@ -6755,6 +6803,19 @@ spec:
                           type: object
                       type: object
                       x-kubernetes-map-type: atomic
+                    matchLabelKeys:
+                      description: MatchLabelKeys is a set of pod label keys to select
+                        the pods over which spreading will be calculated. The keys
+                        are used to lookup values from the incoming pod labels, those
+                        key-value labels are ANDed with labelSelector to select the
+                        group of existing pods over which spreading will be calculated
+                        for the incoming pod. Keys that don't exist in the incoming
+                        pod labels will be ignored. A null or empty list means only
+                        match against labelSelector.
+                      items:
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: atomic
                     maxSkew:
                       description: 'MaxSkew describes the degree to which pods may
                         be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
@@ -6795,11 +6856,31 @@ spec:
                         minimum\" is treated as 0. In this situation, new pod with
                         the same labelSelector cannot be scheduled, because computed
                         skew will be 3(3 - 0) if new Pod is scheduled to any of the
-                        three zones, it will violate MaxSkew. \n This is an alpha
-                        field and requires enabling MinDomainsInPodTopologySpread
-                        feature gate."
+                        three zones, it will violate MaxSkew. \n This is a beta field
+                        and requires the MinDomainsInPodTopologySpread feature gate
+                        to be enabled (enabled by default)."
                       format: int32
                       type: integer
+                    nodeAffinityPolicy:
+                      description: "NodeAffinityPolicy indicates how we will treat
+                        Pod's nodeAffinity/nodeSelector when calculating pod topology
+                        spread skew. Options are: - Honor: only nodes matching nodeAffinity/nodeSelector
+                        are included in the calculations. - Ignore: nodeAffinity/nodeSelector
+                        are ignored. All nodes are included in the calculations. \n
+                        If this value is nil, the behavior is equivalent to the Honor
+                        policy. This is a alpha-level feature enabled by the NodeInclusionPolicyInPodTopologySpread
+                        feature flag."
+                      type: string
+                    nodeTaintsPolicy:
+                      description: "NodeTaintsPolicy indicates how we will treat node
+                        taints when calculating pod topology spread skew. Options
+                        are: - Honor: nodes without taints, along with tainted nodes
+                        for which the incoming pod has a toleration, are included.
+                        - Ignore: node taints are ignored. All nodes are included.
+                        \n If this value is nil, the behavior is equivalent to the
+                        Ignore policy. This is a alpha-level feature enabled by the
+                        NodeInclusionPolicyInPodTopologySpread feature flag."
+                      type: string
                     topologyKey:
                       description: TopologyKey is the key of node labels. Nodes that
                         have a label with this key and identical values are considered
@@ -6807,10 +6888,11 @@ spec:
                         as a "bucket", and try to put balanced number of pods into
                         each bucket. We define a domain as a particular instance of
                         a topology. Also, we define an eligible domain as a domain
-                        whose nodes match the node selector. e.g. If TopologyKey is
-                        "kubernetes.io/hostname", each Node is a domain of that topology.
-                        And, if TopologyKey is "topology.kubernetes.io/zone", each
-                        zone is a domain of that topology. It's a required field.
+                        whose nodes meet the requirements of nodeAffinityPolicy and
+                        nodeTaintsPolicy. e.g. If TopologyKey is "kubernetes.io/hostname",
+                        each Node is a domain of that topology. And, if TopologyKey
+                        is "topology.kubernetes.io/zone", each zone is a domain of
+                        that topology. It's a required field.
                       type: string
                     whenUnsatisfiable:
                       description: 'WhenUnsatisfiable indicates how to deal with a
@@ -8403,11 +8485,58 @@ spec:
               web:
                 description: Defines the web command line flags when starting Prometheus.
                 properties:
+                  httpConfig:
+                    description: Defines HTTP parameters for web server.
+                    properties:
+                      headers:
+                        description: List of headers that can be added to HTTP responses.
+                        properties:
+                          contentSecurityPolicy:
+                            description: Set the Content-Security-Policy header to
+                              HTTP responses. Unset if blank.
+                            type: string
+                          strictTransportSecurity:
+                            description: Set the Strict-Transport-Security header
+                              to HTTP responses. Unset if blank. Please make sure
+                              that you use this with care as this header might force
+                              browsers to load Prometheus and the other applications
+                              hosted on the same domain and subdomains over HTTPS.
+                              https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security
+                            type: string
+                          xContentTypeOptions:
+                            description: Set the X-Content-Type-Options header to
+                              HTTP responses. Unset if blank. Accepted value is nosniff.
+                              https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Content-Type-Options
+                            enum:
+                            - ""
+                            - NoSniff
+                            type: string
+                          xFrameOptions:
+                            description: Set the X-Frame-Options header to HTTP responses.
+                              Unset if blank. Accepted values are deny and sameorigin.
+                              https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options
+                            enum:
+                            - ""
+                            - Deny
+                            - SameOrigin
+                            type: string
+                          xXSSProtection:
+                            description: Set the X-XSS-Protection header to all responses.
+                              Unset if blank. https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection
+                            type: string
+                        type: object
+                      http2:
+                        description: Enable HTTP/2 support. Note that HTTP/2 is only
+                          supported with TLS. When TLSConfig is not configured, HTTP/2
+                          will be disabled. Whenever the value of the field changes,
+                          a rolling update will be triggered.
+                        type: boolean
+                    type: object
                   pageTitle:
                     description: The prometheus web page title
                     type: string
                   tlsConfig:
-                    description: WebTLSConfig defines the TLS parameters for HTTPS.
+                    description: Defines the TLS parameters for HTTPS.
                     properties:
                       cert:
                         description: Contains the TLS certificate for the server.

--- a/charts/prometheus-operator/crds/crd-prometheuses.yaml
+++ b/charts/prometheus-operator/crds/crd-prometheuses.yaml
@@ -5,6 +5,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.2
+    argocd.argoproj.io/sync-options: Replace=true
   creationTimestamp: null
   name: prometheuses.monitoring.coreos.com
 spec:

--- a/charts/prometheus-operator/crds/crd-prometheusrules.yaml
+++ b/charts/prometheus-operator/crds/crd-prometheusrules.yaml
@@ -1,4 +1,4 @@
-# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.58.0/example/prometheus-operator-crd/monitoring.coreos.com_prometheusrules.yaml
+# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.59.1/example/prometheus-operator-crd/monitoring.coreos.com_prometheusrules.yaml
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/charts/prometheus-operator/crds/crd-prometheusrules.yaml
+++ b/charts/prometheus-operator/crds/crd-prometheusrules.yaml
@@ -5,6 +5,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.2
+    argocd.argoproj.io/sync-options: Replace=true
   creationTimestamp: null
   name: prometheusrules.monitoring.coreos.com
 spec:

--- a/charts/prometheus-operator/crds/crd-servicemonitors.yaml
+++ b/charts/prometheus-operator/crds/crd-servicemonitors.yaml
@@ -1,4 +1,4 @@
-# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.58.0/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml
+# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.59.1/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/charts/prometheus-operator/crds/crd-servicemonitors.yaml
+++ b/charts/prometheus-operator/crds/crd-servicemonitors.yaml
@@ -5,6 +5,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.2
+    argocd.argoproj.io/sync-options: Replace=true
   creationTimestamp: null
   name: servicemonitors.monitoring.coreos.com
 spec:

--- a/charts/prometheus-operator/crds/crd-thanosrulers.yaml
+++ b/charts/prometheus-operator/crds/crd-thanosrulers.yaml
@@ -1,4 +1,4 @@
-# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.58.0/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
+# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.59.1/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -1508,13 +1508,13 @@ spec:
                         Cannot be updated.
                       type: string
                     ports:
-                      description: List of ports to expose from the container. Exposing
-                        a port here gives the system additional information about
-                        the network connections a container uses, but is primarily
-                        informational. Not specifying a port here DOES NOT prevent
-                        that port from being exposed. Any port which is listening
-                        on the default "0.0.0.0" address inside a container will be
-                        accessible from the network. Cannot be updated.
+                      description: List of ports to expose from the container. Not
+                        specifying a port here DOES NOT prevent that port from being
+                        exposed. Any port which is listening on the default "0.0.0.0"
+                        address inside a container will be accessible from the network.
+                        Modifying this array with strategic merge patch may corrupt
+                        the data. For more information See https://github.com/kubernetes/kubernetes/issues/108255.
+                        Cannot be updated.
                       items:
                         description: ContainerPort represents a network port in a
                           single container.
@@ -2955,13 +2955,13 @@ spec:
                         Cannot be updated.
                       type: string
                     ports:
-                      description: List of ports to expose from the container. Exposing
-                        a port here gives the system additional information about
-                        the network connections a container uses, but is primarily
-                        informational. Not specifying a port here DOES NOT prevent
-                        that port from being exposed. Any port which is listening
-                        on the default "0.0.0.0" address inside a container will be
-                        accessible from the network. Cannot be updated.
+                      description: List of ports to expose from the container. Not
+                        specifying a port here DOES NOT prevent that port from being
+                        exposed. Any port which is listening on the default "0.0.0.0"
+                        address inside a container will be accessible from the network.
+                        Modifying this array with strategic merge patch may corrupt
+                        the data. For more information See https://github.com/kubernetes/kubernetes/issues/108255.
+                        Cannot be updated.
                       items:
                         description: ContainerPort represents a network port in a
                           single container.
@@ -4731,6 +4731,19 @@ spec:
                           type: object
                       type: object
                       x-kubernetes-map-type: atomic
+                    matchLabelKeys:
+                      description: MatchLabelKeys is a set of pod label keys to select
+                        the pods over which spreading will be calculated. The keys
+                        are used to lookup values from the incoming pod labels, those
+                        key-value labels are ANDed with labelSelector to select the
+                        group of existing pods over which spreading will be calculated
+                        for the incoming pod. Keys that don't exist in the incoming
+                        pod labels will be ignored. A null or empty list means only
+                        match against labelSelector.
+                      items:
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: atomic
                     maxSkew:
                       description: 'MaxSkew describes the degree to which pods may
                         be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
@@ -4771,11 +4784,31 @@ spec:
                         minimum\" is treated as 0. In this situation, new pod with
                         the same labelSelector cannot be scheduled, because computed
                         skew will be 3(3 - 0) if new Pod is scheduled to any of the
-                        three zones, it will violate MaxSkew. \n This is an alpha
-                        field and requires enabling MinDomainsInPodTopologySpread
-                        feature gate."
+                        three zones, it will violate MaxSkew. \n This is a beta field
+                        and requires the MinDomainsInPodTopologySpread feature gate
+                        to be enabled (enabled by default)."
                       format: int32
                       type: integer
+                    nodeAffinityPolicy:
+                      description: "NodeAffinityPolicy indicates how we will treat
+                        Pod's nodeAffinity/nodeSelector when calculating pod topology
+                        spread skew. Options are: - Honor: only nodes matching nodeAffinity/nodeSelector
+                        are included in the calculations. - Ignore: nodeAffinity/nodeSelector
+                        are ignored. All nodes are included in the calculations. \n
+                        If this value is nil, the behavior is equivalent to the Honor
+                        policy. This is a alpha-level feature enabled by the NodeInclusionPolicyInPodTopologySpread
+                        feature flag."
+                      type: string
+                    nodeTaintsPolicy:
+                      description: "NodeTaintsPolicy indicates how we will treat node
+                        taints when calculating pod topology spread skew. Options
+                        are: - Honor: nodes without taints, along with tainted nodes
+                        for which the incoming pod has a toleration, are included.
+                        - Ignore: node taints are ignored. All nodes are included.
+                        \n If this value is nil, the behavior is equivalent to the
+                        Ignore policy. This is a alpha-level feature enabled by the
+                        NodeInclusionPolicyInPodTopologySpread feature flag."
+                      type: string
                     topologyKey:
                       description: TopologyKey is the key of node labels. Nodes that
                         have a label with this key and identical values are considered
@@ -4783,10 +4816,11 @@ spec:
                         as a "bucket", and try to put balanced number of pods into
                         each bucket. We define a domain as a particular instance of
                         a topology. Also, we define an eligible domain as a domain
-                        whose nodes match the node selector. e.g. If TopologyKey is
-                        "kubernetes.io/hostname", each Node is a domain of that topology.
-                        And, if TopologyKey is "topology.kubernetes.io/zone", each
-                        zone is a domain of that topology. It's a required field.
+                        whose nodes meet the requirements of nodeAffinityPolicy and
+                        nodeTaintsPolicy. e.g. If TopologyKey is "kubernetes.io/hostname",
+                        each Node is a domain of that topology. And, if TopologyKey
+                        is "topology.kubernetes.io/zone", each zone is a domain of
+                        that topology. It's a required field.
                       type: string
                     whenUnsatisfiable:
                       description: 'WhenUnsatisfiable indicates how to deal with a
@@ -4832,6 +4866,11 @@ spec:
                 - key
                 type: object
                 x-kubernetes-map-type: atomic
+              tracingConfigFile:
+                description: TracingConfig specifies the path of the tracing configuration
+                  file. When used alongside with TracingConfig, TracingConfigFile
+                  takes precedence.
+                type: string
               volumes:
                 description: Volumes allows configuration of additional volumes on
                   the output StatefulSet definition. Volumes specified will be appended

--- a/charts/prometheus-operator/crds/crd-thanosrulers.yaml
+++ b/charts/prometheus-operator/crds/crd-thanosrulers.yaml
@@ -5,6 +5,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.2
+    argocd.argoproj.io/sync-options: Replace=true
   creationTimestamp: null
   name: thanosrulers.monitoring.coreos.com
 spec:

--- a/charts/prometheus-operator/values.yaml
+++ b/charts/prometheus-operator/values.yaml
@@ -81,7 +81,7 @@ admissionWebhooks:
     enabled: true
     image:
       repository: k8s.gcr.io/ingress-nginx/kube-webhook-certgen
-      tag: v1.2.0
+      tag: v1.3.0
       sha: ""
       pullPolicy: IfNotPresent
     resources: {}
@@ -320,7 +320,7 @@ containerSecurityContext:
 ##
 image:
   repository: quay.io/prometheus-operator/prometheus-operator
-  tag: v0.58.0
+  tag: v0.59.1
   sha: ""
   pullPolicy: IfNotPresent
 
@@ -338,7 +338,7 @@ prometheusConfigReloader:
   # image to use for config and rule reloading
   image:
     repository: quay.io/prometheus-operator/prometheus-config-reloader
-    tag: v0.58.0
+    tag: v0.59.1
     sha: ""
 
   # resource config for prometheusConfigReloader
@@ -354,7 +354,7 @@ prometheusConfigReloader:
 ##
 thanosImage:
   repository: quay.io/thanos/thanos
-  tag: v0.27.0
+  tag: v0.28.0
   sha: ""
 
   ## Set a Field Selector to filter watched secrets


### PR DESCRIPTION
- [x] Update CRDs to prometheus operator version v0.59.1
- [x] Add  ArgoCD annotations on CRDs for replace sync policy in order to avoid manual serverside apply
- [x] Update doc